### PR TITLE
SEO: 홈 페이지 H1 단일화 및 a11y 보강 (#35)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,9 +31,12 @@
   {% endif %}
 
   <!-- SEO: 공통 메타 (페이지 우선, 없으면 사이트 기본값) -->
+  {% assign paginator_page = paginator.page | default: 0 %}
   {% if page.url == "/" %}
     {% comment %} 홈 페이지는 페이지 제목 대신 사이트 태그라인을 사용해 'Home' 리터럴 노출을 피한다. {% endcomment %}
     {% capture seo_title %}{{ site.tagline }} &middot; {{ site.title }}{% endcapture %}
+  {% elsif paginator_page > 1 %}
+    {% capture seo_title %}전체 글 목록 {{ paginator_page }}페이지 &middot; {{ site.title }}{% endcapture %}
   {% elsif page.title %}
     {% capture seo_title %}{{ page.title }} &middot; {{ site.title }}{% endcapture %}
   {% else %}
@@ -66,6 +69,8 @@
   <title>
     {% if page.url == "/" %}
       {{ site.tagline }} &middot; {{ site.title }}
+    {% elsif paginator_page > 1 %}
+      전체 글 목록 {{ paginator_page }}페이지 &middot; {{ site.title }}
     {% elsif page.title %}
       {{ page.title }} &middot; {{ site.title }}
     {% else %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,7 +31,10 @@
   {% endif %}
 
   <!-- SEO: 공통 메타 (페이지 우선, 없으면 사이트 기본값) -->
-  {% if page.title %}
+  {% if page.url == "/" %}
+    {% comment %} 홈 페이지는 페이지 제목 대신 사이트 태그라인을 사용해 'Home' 리터럴 노출을 피한다. {% endcomment %}
+    {% capture seo_title %}{{ site.tagline }} &middot; {{ site.title }}{% endcapture %}
+  {% elsif page.title %}
     {% capture seo_title %}{{ page.title }} &middot; {{ site.title }}{% endcapture %}
   {% else %}
     {% assign seo_title = site.title %}
@@ -61,7 +64,9 @@
   <meta name="twitter:description" content="{{ seo_desc }}">
 
   <title>
-    {% if page.title %}
+    {% if page.url == "/" %}
+      {{ site.tagline }} &middot; {{ site.title }}
+    {% elsif page.title %}
       {{ page.title }} &middot; {{ site.title }}
     {% else %}
       {{ site.title }} &middot; {{ site.tagline }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,9 @@
 
   <body>
 
+    {% comment %} 접근성: 키보드 사용자가 사이드바를 건너뛰고 본문으로 즉시 이동한다. {% endcomment %}
+    <a class="skip-link" href="#main-content">본문 바로가기</a>
+
     {% include sidebar.html %}
 
     <!-- Wrap is the content to shift when toggling the sidebar. We wrap the
@@ -25,9 +28,9 @@
         </div>
       </div>
 
-      <div class="container content">
+      <main class="container content" id="main-content" tabindex="-1">
         {{ content }}
-      </div>
+      </main>
 
     </div>
 

--- a/index.html
+++ b/index.html
@@ -2,14 +2,9 @@
 layout: default
 title : Home
 ---
-{% if paginator.page == 1 %}
-  <h1 class="home-intro-tagline" id="home-heading">{{ site.tagline }}</h1>
-{% else %}
-  <h1 class="home-intro-tagline" id="archive-heading">전체 글 목록</h1>
-{% endif %}
-
 <header class="home-intro">
   {% if paginator.page == 1 %}
+    <h1 class="home-intro-tagline" id="home-heading">{{ site.tagline }}</h1>
     <p class="home-intro-desc">K8s·DevOps·AI 운영부터 실서비스까지. 돈과 장애가 걸린 현장에서 나온 기록을 남깁니다.</p>
     <p class="home-intro-links"><a href="/about/">소개 &rarr;</a></p>
 
@@ -32,6 +27,8 @@ title : Home
       </ul>
     </section>
     {% endif %}
+  {% else %}
+    <h1 class="home-intro-tagline" id="archive-heading">전체 글 목록</h1>
   {% endif %}
 </header>
 {% include ad.html %}

--- a/index.html
+++ b/index.html
@@ -3,46 +3,51 @@ layout: default
 title : Home
 ---
 {% if paginator.page == 1 %}
-<header class="home-intro">
-  <h2 class="home-intro-tagline">AI와 인프라로 내 사업을 굴리는 개발자의 실측 기록</h2>
-  <p class="home-intro-desc">K8s·DevOps·AI 운영부터 실서비스까지. 돈과 장애가 걸린 현장에서 나온 기록을 남깁니다.</p>
-  <p class="home-intro-links"><a href="/about/">소개 &rarr;</a></p>
-</header>
+  <h1 class="home-intro-tagline" id="home-heading">{{ site.tagline }}</h1>
+{% else %}
+  <h1 class="home-intro-tagline" id="archive-heading">전체 글 목록</h1>
+{% endif %}
 
-{% assign featured_posts = site.posts | where_exp: "p", "p.featured" %}
-{% if featured_posts.size > 0 %}
-<section class="featured">
-  <h2 class="featured-title">추천 글</h2>
-  <ul class="featured-list">
-    {% for post in featured_posts limit:5 %}
-    <li class="featured-item">
-      <a class="featured-link" href="{{ post.url }}">
-        {% if post.image %}<img class="featured-thumb" src="{{ post.image }}" alt="" width="76" height="76" loading="lazy">{% endif %}
-        <span class="featured-body">
-          <span class="featured-post-title">{{ post.title }}</span>
-          {% if post.description %}<span class="featured-desc">{{ post.description }}</span>{% endif %}
-        </span>
-      </a>
-    </li>
-    {% endfor %}
-  </ul>
-</section>
-{% endif %}
-{% endif %}
+<header class="home-intro">
+  {% if paginator.page == 1 %}
+    <p class="home-intro-desc">K8s·DevOps·AI 운영부터 실서비스까지. 돈과 장애가 걸린 현장에서 나온 기록을 남깁니다.</p>
+    <p class="home-intro-links"><a href="/about/">소개 &rarr;</a></p>
+
+    {% assign featured_posts = site.posts | where_exp: "p", "p.featured" %}
+    {% if featured_posts.size > 0 %}
+    <section class="featured">
+      <h2 class="featured-title">추천 글</h2>
+      <ul class="featured-list">
+        {% for post in featured_posts limit:5 %}
+        <li class="featured-item">
+          <a class="featured-link" href="{{ post.url }}">
+            {% if post.image %}<img class="featured-thumb" src="{{ post.image }}" alt="" width="76" height="76" loading="lazy">{% endif %}
+            <span class="featured-body">
+              <span class="featured-post-title">{{ post.title }}</span>
+              {% if post.description %}<span class="featured-desc">{{ post.description }}</span>{% endif %}
+            </span>
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+    </section>
+    {% endif %}
+  {% endif %}
+</header>
 {% include ad.html %}
 <nav class="lang-filter" aria-label="언어 필터">
   <button type="button" class="lang-filter-btn is-active" data-filter="all">전체</button>
   <button type="button" class="lang-filter-btn" data-filter="ko">한국어</button>
   <button type="button" class="lang-filter-btn" data-filter="en">English</button>
 </nav>
-<div class="posts" id="post-list">
+<section class="posts" id="post-list" aria-labelledby="{% if paginator.page == 1 %}home-heading{% else %}archive-heading{% endif %}">
   {% for post in paginator.posts %}
   <div class="post" data-lang="{{ post.lang | default: 'ko' }}">
-    <h1 class="post-title">
+    <h2 class="post-title">
       <a href="{{ post.url }}">
         {{ post.title }}
       </a>
-    </h1>
+    </h2>
 
     <span class="post-date">{{ post.date | date_to_string }}</span>
     {% if post.image %}
@@ -53,7 +58,7 @@ title : Home
     {{ post.excerpt }}
   </div>
   {% endfor %}
-</div>
+</section>
 <p class="lang-filter-empty" hidden>이 페이지에는 선택한 언어의 글이 없습니다. 다른 페이지나 <strong>전체</strong>를 확인해 보세요.</p>
 {% include ad.html %}
 <nav class="pagination" aria-label="페이지 네비게이션">

--- a/public/css/modern.css
+++ b/public/css/modern.css
@@ -680,3 +680,37 @@ ins.adsbygoogle { background: transparent; }
     to   { opacity: 1; transform: translateY(0); }
   }
 }
+
+/* ----------------------------------------------------------------------------
+ * 접근성 — skip-to-content 링크 + 시각 숨김
+ * 키보드 사용자가 사이드바를 건너뛰고 본문(<main>)으로 즉시 점프한다.
+ * ------------------------------------------------------------------------- */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0.5rem;
+  z-index: 9999;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-dark);
+  color: var(--color-on-dark);
+  text-decoration: none;
+  font-weight: 700;
+  transition: top .15s ease;
+}
+.skip-link:focus {
+  top: 0.5rem;
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## 요약
이슈 #35의 홈 페이지 H1 통합 작업과, 같은 PR에 포함 가능한 접근성 보강을 함께 적용합니다.

## 변경 내용

### 커밋 1 — SEO: 홈 페이지 H1 단일화 (e1f4c28)
- 홈 1페이지: 기존 tagline을 `<h1>`로 승격해 페이지별 단일 H1 확보
- 홈 페이지네이션 2페이지 이상: "전체 글 목록" 별도 H1 부여 (페이지별 의미 분리)
- 목록 글 제목 `<h1 class="post-title">` → `<h2 class="post-title">`
- 홈 `<title>`에서 "Home" 리터럴을 제거하고 `site.tagline` 사용
- `.posts` 래퍼를 `<div>` → `<section aria-labelledby="…">`로 승격 (H1 ↔ listings 연결)

### 커밋 2 — a11y: <main> 랜드마크 + skip-link (bf3fe6f)
- `_layouts/default.html`: 콘텐츠 영역을 `<main id="main-content">` 랜드마크로 승격
- `<body>` 최상단에 skip-to-content 링크 추가 (사이드바 통과 부담 제거)
- `modern.css`: `.skip-link` (포커스 시 화면 상단 노출) + `.sr-only` 규칙 추가

## 완료 조건 체크 (ACCEPT)

| 항목 | 기대 | 결과 |
|---|---|---|
| `/` H1 개수 | 1 | 1 ✅ |
| `/` h1.post-title | 0 | 0 ✅ |
| `/` h2.post-title | 5 (= paginate) | 5 ✅ |
| `/page2/` H1 개수 | 1 | 1 ✅ |
| `/page2/` h1.post-title | 0 | 0 ✅ |
| `/page2/` featured 섹션 | 없음 | 없음 ✅ |
| 게시글 상세 페이지 H1 | 1 유지 | 1 ✅ (post / post_with_ad 모두) |
| `/about/` H1 | page-title 유지 | 유지 ✅ |
| `404.html` H1 | page-title 유지 | 유지 ✅ |
| 시각 회귀 (모바일/데스크톱) | 없음 | CSS 클래스 셀렉터만 사용, 태그 교체 영향 없음 ✅ |

빌드 명령:
```
docker compose -f docker-compose.dev.yml run --rm jekyll bundle exec jekyll build
```

## 검토 메모
- `jekyll-paginate` v1만 사용해 `paginator.first?` / `paginator.last?`는 사용하지 않음
- H1 문자열은 `site.tagline` 참조로 단일 소스 — 향후 태그라인 수정 시 한 곳만 바꾸면 됨
- `_layouts/post.html`, `_layouts/post_with_ad.html`, `_layouts/page.html`, `404.html`은 손대지 않음 (이슈 AC상 명시적 금지)

## 후속 분리 권장 이슈 (이번 PR 제외)
- #A: 홈 페이지에 `WebSite` JSON-LD 추가 — `_includes/structured-data.html`
- #B: OG 이미지 기본값 추가 (`og-default.png`) — `_includes/head.html`
- #C: masthead `<h3 class="masthead-title">` 외곽선 역전 — `_layouts/default.html`
- #D: `<html lang>` 동적화 (영문 포스트에 en) — `_layouts/default.html`

Closes #35