### PR TITLE
[TODO-36] 영문 MariaDB 복제 글의 검색 의도 적합성 점검

### DIFF
--- a/_posts/mariadb/2024-06-14-replication-on-mariadb-en.md
+++ b/_posts/mariadb/2024-06-14-replication-on-mariadb-en.md
@@ -172,18 +172,31 @@ Apply Node B's unique option-file settings, then restart both nodes:
 sudo systemctl restart mariadb
 ```
 
-Before any write occurs on Node B, copy the GTID value from the recorded `mariadb_backup_binlog_info` into the replica position. Replace the example with the complete GTID set from the backup metadata; do not copy the binlog filename or byte position into this variable.
+Before any write occurs on Node B, confirm that its new binary log and replica state are empty:
 
 ```sql
+SELECT
+  @@global.gtid_binlog_state,
+  @@global.gtid_binlog_pos,
+  @@global.gtid_slave_pos;
+```
+
+All three values must be empty. MariaDB Backup does not copy binary logs, so this clean state is expected after a fresh restore. If any value is nonempty, stop and rebuild Node B from a fresh snapshot. Do not use `RESET MASTER` to force this check to pass.
+
+Copy the complete GTID set from the recorded `mariadb_backup_binlog_info` into both Node B's binary-log history and replica position. Replace the example with the complete metadata value; do not copy the binlog filename or byte position into these variables.
+
+```sql
+SET GLOBAL gtid_binlog_state='101-11-12345';
 SET GLOBAL gtid_slave_pos='101-11-12345';
 
 SELECT
+  @@global.gtid_binlog_state,
+  @@global.gtid_binlog_pos,
   @@global.gtid_slave_pos,
-  @@global.gtid_current_pos,
-  @@global.gtid_binlog_pos;
+  @@global.gtid_current_pos;
 ```
 
-MariaDB Backup records a primary's GTID in the backup metadata, but restoring the physical files does not automatically make that primary GTID Node B's replicated position. Setting `gtid_slave_pos` tells Node B which snapshot transactions are already present. Confirm that no replica connection or thread exists before setting it, and stop if the metadata is missing, malformed, or differs from the position recorded on Node A.
+MariaDB Backup records a primary's GTID in the backup metadata, but restoring the physical files does not automatically restore the primary's binary-log history or make that GTID Node B's replicated position. `gtid_binlog_state` lets Node B, when it acts as a primary, recognize the snapshot history whose binary-log files were not copied. `gtid_slave_pos` records which snapshot transactions are already present in the restored data. Confirm that no replica connection or thread exists before setting them, and stop if the metadata is missing, malformed, or differs from the position recorded on Node A.
 
 Confirm the effective identities:
 
@@ -208,7 +221,7 @@ Compare representative row counts, checksums appropriate to the dataset, the bac
 MariaDB GTIDs use `domain-server-sequence` components. Parse and compare those components instead of trusting an unexamined string comparison. Before the initial ring connections, verify that:
 
 1. Node A's recorded snapshot position matches the complete GTID set in `mariadb_backup_binlog_info`;
-2. Node B's `gtid_slave_pos` contains that same snapshot-derived domain/server/sequence set;
+2. Node B's `gtid_binlog_state` and `gtid_slave_pos` contain that same snapshot-derived domain/server/sequence set;
 3. both nodes' `gtid_current_pos` contain the same snapshot position and neither node has any post-snapshot local GTID;
 4. both nodes contain the same restored data.
 
@@ -216,7 +229,7 @@ The configured `gtid_domain_id` values differ so future local transactions can u
 
 ## Connect both replication directions
 
-`MASTER_USE_GTID=current_pos` is safe here only because writes remain frozen, Node B's `gtid_slave_pos` was initialized from the backup metadata, and the previous step proved that neither node has a post-snapshot local GTID. A local write while replication is stopped changes `gtid_current_pos` to a position the peer may not have; if that happens before both directions are connected, discard this bootstrap attempt and start again from a fresh snapshot.
+`MASTER_USE_GTID=current_pos` is safe here only because writes remain frozen, Node B's `gtid_binlog_state` and `gtid_slave_pos` were initialized from the backup metadata, and the previous step proved that neither node has a post-snapshot local GTID. A local write while replication is stopped changes `gtid_current_pos` to a position the peer may not have; if that happens before both directions are connected, discard this bootstrap attempt and start again from a fresh snapshot.
 
 On Node B, connect to Node A:
 
@@ -355,6 +368,7 @@ Capture `SHOW REPLICA STATUS\G`, the relevant MariaDB error log, both GTID sets,
 - [AUTO_INCREMENT](https://mariadb.com/docs/server/reference/data-types/auto_increment)
 - [SHOW REPLICA STATUS](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-replica-status)
 - [Files Created by mariadb-backup](https://mariadb.com/docs/server/server-usage/backup-and-restore/mariadb-backup/files-created-by-mariadb-backup)
+- [Files Backed Up by mariadb-backup](https://mariadb.com/docs/server/server-usage/backup-and-restore/mariadb-backup/files-backed-up-by-mariadb-backup)
 - [Setting up a Replica with mariadb-backup](https://mariadb.com/docs/server/server-usage/backup-and-restore/mariadb-backup/setting-up-a-replica-with-mariadb-backup)
 
 ## Related reading

--- a/_posts/mariadb/2024-06-14-replication-on-mariadb-en.md
+++ b/_posts/mariadb/2024-06-14-replication-on-mariadb-en.md
@@ -1,160 +1,344 @@
 ---
 layout: post_with_ad
-title: Setting up replication in MariaDB 11 version
+title: "MariaDB 11.4 Master-Master Replication: Safe Two-Node GTID Ring"
 date: 2024-06-14 11:04:51 +0900
+last_modified_at: 2026-07-26 14:56:00 +0900
 permalink: /en/mariadb/2024-06-14-replication-on-mariadb
 categories: mariadb
-tags: mariadb, replication, slave, master
-excerpt: Let's learn about MariaDB replication.
+tags: [mariadb, replication, gtid, master-master, ring-replication]
+excerpt: "Build a two-node MariaDB 11.4 GTID ring with a consistent snapshot, unique server identities, serialized write tests, and fail-closed verification."
 lang: en
-description: "Learn how to configure master-slave replication on MariaDB 11: what replication is, its benefits, and the step-by-step setup for distributing data across servers."
+description: "Configure two-node MariaDB 11.4 master-master ring replication with GTID, a consistent snapshot, conflict-safe write ownership, and verifiable health checks."
+mermaid: true
 ---
 
-## What is MariaDB Replication?
+A two-node MariaDB 11.4 master-master setup is an **asynchronous GTID ring**: each node is both a primary and a replica of the other. Both nodes must run the same MariaDB 11.4.x major-minor release and start from one consistent snapshot. Ring replication is not Galera and has no automatic conflict resolution, so production writes need documented row- or table-level single-writer ownership.
 
-MariaDB replication is the process of automatically transferring data changes that occur on a master database server to one or more slave database servers. This allows for maintaining duplicate copies of data, providing the following benefits:
+This guide uses the historical term *master-master* once for search compatibility. The explanation otherwise uses *primary*, *replica*, Node A, and Node B; MariaDB SQL such as `CHANGE MASTER TO` and status fields such as `Master_Host` retain their official names.
 
-- Data distribution and load balancing
-- Data backup and recovery
-- Failover and high availability
-- Support for data warehousing and data mining analysis tasks
+## Scope and safety contract
 
-## Overview of the Replication Process
+Use this procedure only when all of these conditions are true:
 
-1. The master server records SQL statements in the binary log.
-2. The I/O thread of the slave server reads the binary log events from the master and records them in the relay log.
-3. The SQL thread of the slave executes the relay log events to replicate the data.
+- Node A and Node B both run MariaDB 11.4.x.
+- Application writes can be frozen during bootstrap and verification.
+- The nodes can reach each other on the MariaDB port through a protected network path.
+- One consistent Node A snapshot will initialize Node B.
+- Every active table or row range has one documented writer. The same row or key is never changed concurrently on both nodes.
+- DDL and schema changes run during one coordinated maintenance window, on one node at a time, after writes are stopped.
 
-## Replication Setup Process
+This setup does not provide synchronous commits, automatic failover, or conflict resolution. Use [MariaDB Galera Cluster](https://mariadb.com/docs/galera-cluster/) when the requirement is synchronous multi-primary behavior rather than an asynchronous ring.
 
-1. Master server configuration
-    1. Enable binary logging
-    2. Assign a unique server ID
-2. Configure the master server information on the slave server
-3. Start the replication process on the slave
+## Two-node ring topology
 
-After this, data changes on the master server are automatically replicated to the slave. You can monitor the replication status and perform failover if necessary.
-
----
-
-### MariaDB Server Configuration
-
-- server-id: Sets the unique identifier for the server. Used to identify each server when operating multiple servers.
-- log_bin: Specifies the path to the binary log file. Used to log database changes and track the state of the database.
-- expire_logs_days: Sets the number of days the binary log files are retained. Previous log files are automatically deleted after the specified number of days.
-- max_binlog_size: Sets the maximum size of the binary log file. A new log file is created when the file size exceeds the specified size.
-
----
-
-# Configuration
-
-MariaDB 11 version does not have the `mysql` command, instead, it is executed with the `mariadb` command.
-
-## 1. Master
-
-### 1.1 Configuration
-
-Configure `/etc/mysql/mariadb.conf.d/50-server.cnf`. It works as described for each setting above.
-
-```bash
-server-id              = 1
-log_bin                = /var/log/mysql/mysql-bin.log
-expire_logs_days       = 10
-max_binlog_size        = 100M
+```mermaid
+flowchart LR
+    A["Node A<br/>MariaDB 11.4.x<br/>Primary for owned rows/tables"]
+    B["Node B<br/>MariaDB 11.4.x<br/>Primary for different owned rows/tables"]
+    A -->|"async GTID replication"| B
+    B -->|"async GTID replication"| A
 ```
 
-<aside>
-💡 Tested with server-id set to 0, but it did not work properly. server-id must start from 1
+Each node writes its local transactions to the binary log and also logs replicated transactions with `log_slave_updates`. Unique `server_id` values let a returning event be recognized instead of circulating forever. Unique `gtid_domain_id` values distinguish transactions generated by each primary.
 
-Fatal error: The slave I/O thread stops because master and slave have equal MariaDB server ids; these ids must be different for replication to work (or the --replicate-same-server-id option must be used on slave but this does not always make sense; please check the manual before using it).
+## Prerequisites
 
-</aside>
+### Confirm the same MariaDB 11.4.x release
 
-### 1.2 Create an account for the slave
-
-Run `mariadb -u root -p` to create an account to be used on the slave.
+Run this on both nodes:
 
 ```sql
-grant replication slave on *.* to 'slave_db' @'%' identified by 'slave_password';
+SELECT VERSION();
 ```
 
-Restart MariaDB afterwards.
+Both results must begin with `11.4.`. Mixed minor releases and cross-version migrations are outside this guide's support contract.
 
-```bash
-service mariadb restart #필요시 sudo
+Example network values used below:
+
+| Role | Host | Address |
+| --- | --- | --- |
+| Node A | `db-a.example.net` | `10.0.0.11` |
+| Node B | `db-b.example.net` | `10.0.0.12` |
+
+Replace every example hostname, address, user, and secret. Restrict the replication port with a firewall and use TLS when traffic crosses an untrusted network.
+
+### Assign write ownership before enabling the ring
+
+Write down which node owns each table or row range. Even with separate `AUTO_INCREMENT` sequences, two nodes can still update or delete the same row differently. Do not enable application writes until the ownership rules and a single coordinated DDL window are enforced.
+
+## Configure unique node identities
+
+Apply these settings in the MariaDB server option file, such as `/etc/mysql/mariadb.conf.d/50-server.cnf`.
+
+Node A:
+
+```ini
+[mariadb]
+server_id=11
+gtid_domain_id=101
+log_bin=mariadb-bin
+binlog_format=ROW
+log_slave_updates=ON
+gtid_strict_mode=ON
+auto_increment_increment=2
+auto_increment_offset=1
 ```
 
-### **1.3 check binay log **
+Node B:
+
+```ini
+[mariadb]
+server_id=12
+gtid_domain_id=102
+log_bin=mariadb-bin
+binlog_format=ROW
+log_slave_updates=ON
+gtid_strict_mode=ON
+auto_increment_increment=2
+auto_increment_offset=2
+```
+
+The increment of `2` gives Node A odd generated IDs and Node B even generated IDs. It reduces `AUTO_INCREMENT` collisions, but it does not resolve conflicting updates, explicit duplicate keys, or divergent DDL.
+
+Do not restart Node B with an empty or unrelated data directory yet. The safe bootstrap order below restores the shared snapshot before the final Node B start.
+
+## Bootstrap both nodes from one snapshot
+
+### 1. Freeze writes and create the replication accounts
+
+Stop application and maintenance writes on both nodes. On canonical Node A, create only the accounts that the two peer addresses need:
 
 ```sql
-show master status;
+CREATE USER 'repl_ring'@'10.0.0.11' IDENTIFIED BY 'replace-with-a-secret';
+CREATE USER 'repl_ring'@'10.0.0.12' IDENTIFIED BY 'replace-with-a-secret';
+
+GRANT REPLICATION SLAVE ON *.* TO 'repl_ring'@'10.0.0.11';
+GRANT REPLICATION SLAVE ON *.* TO 'repl_ring'@'10.0.0.12';
 ```
 
-```bash
-MariaDB [(none)]> show master status;
-```
+Create the accounts before the snapshot so the account transactions and grants are present on both nodes after restore. Prefer exact peer addresses over `%`, protect credentials outside shell history, and configure certificate verification when TLS is required.
 
-```bash
-+------------------+----------+--------------+------------------+
-| File             | Position | Binlog_Do_DB | Binlog_Ignore_DB |
-+------------------+----------+--------------+------------------+
-| mysql-bin.000002 |      342 |              |                  |
-+------------------+----------+--------------+------------------+
-1 row in set (0.000 sec)
-```
+### 2. Record Node A state and take the backup
 
-Save the File and Position values. The Position value will change every time there is a change in the master database.
-
-# Slave
-
-### 1.1 Configuration
-
-Configure `/etc/mysql/mariadb.conf.d/50-server.cnf`.
-
-```bash
-server-id              = 2
-```
-
-<aside>
-💡 The slave can operate even if only the `server-id` is set. If necessary, other options can also be specified.
-
-</aside>
-
-Restart MariaDB.
-
-```bash
-service mariadb restart # if necessary sudo
-```
-
-### 1.2 set master infomation
-
-Assume that the IP of the server where the master is running is 192.168.0.100 and the port is 3306.
-
-Run `show master status;` and put the obtained value `FILE` as `MASTER_LOG_FILE`, `Position` as `MASTER_LOG_POS`.
+With application writes still frozen, record the live GTID set:
 
 ```sql
-CHANGE MASTER TO MASTER_HOST = "192.168.0.100",
-MASTER_USER = "slave_db",
-MASTER_PASSWORD = "slave_password",
-MASTER_PORT = 3306,
-MASTER_LOG_FILE = "mysql-bin.000002",
-MASTER_LOG_POS = 342;
+SELECT @@global.gtid_current_pos;
+SHOW MASTER STATUS;
 ```
 
-If it is applied correctly, start the slave.
+Take a full physical backup with the MariaDB Backup version compatible with MariaDB 11.4.x:
+
+```bash
+sudo mariadb-backup \
+  --backup \
+  --binlog-info=ON \
+  --target-dir=/backup/node-a \
+  --user=backup_operator \
+  --password
+```
+
+Record the generated backup metadata without editing it:
+
+```bash
+sudo cat /backup/node-a/mariadb_backup_binlog_info
+```
+
+The metadata stores the binary-log coordinates and the `gtid_current_pos` associated with the backup. Keep it together with the earlier SQL output and backup checksum.
+
+Prepare the snapshot:
+
+```bash
+sudo mariadb-backup \
+  --prepare \
+  --target-dir=/backup/node-a
+```
+
+### 3. Restore the snapshot on Node B
+
+Stop MariaDB on Node B. Its destination data directory must be empty; preserve any old directory separately instead of overwriting it.
+
+```bash
+sudo systemctl stop mariadb
+sudo mariadb-backup \
+  --copy-back \
+  --target-dir=/backup/node-a
+sudo chown -R mysql:mysql /var/lib/mysql
+```
+
+Apply Node B's unique option-file settings, then restart both nodes:
+
+```bash
+sudo systemctl restart mariadb
+```
+
+Confirm the effective identities:
 
 ```sql
-start slave;
+SELECT
+  @@global.server_id,
+  @@global.gtid_domain_id,
+  @@global.log_bin,
+  @@global.log_slave_updates,
+  @@global.gtid_strict_mode,
+  @@global.auto_increment_increment,
+  @@global.auto_increment_offset,
+  @@global.gtid_current_pos;
 ```
 
-# Test
+Node A must report server/domain `11/101` and offset `1`; Node B must report `12/102` and offset `2`.
 
-If you connect to the master and execute the following, you can confirm that it is applied the same way on the slave.
+### 4. Compare data and GTID provenance before connecting
+
+Compare representative row counts, checksums appropriate to the dataset, the backup metadata, and `@@global.gtid_current_pos` on both nodes.
+
+MariaDB GTIDs use `domain-server-sequence` components. Because the nodes have different `gtid_domain_id` values, do **not** require the complete GTID strings to be textually equal. Instead, verify that:
+
+1. every snapshot-derived domain and sequence matches the recorded backup metadata;
+2. both nodes contain the same restored data;
+3. any additional local transaction is expected, documented with its domain/server/sequence, and explained;
+4. no unplanned write occurred after the snapshot.
+
+If the data differs, snapshot-derived GTIDs are missing, or an unexplained local GTID exists, stop here. Do not run `CHANGE MASTER TO`.
+
+## Connect both replication directions
+
+`MASTER_USE_GTID=current_pos` is safe here only because writes remain frozen and the previous step proved the current positions came from the common snapshot plus documented local transactions. Local writes while replication is stopped change `gtid_current_pos`; if that happens, repeat the fail-closed comparison before connecting.
+
+On Node B, connect to Node A:
 
 ```sql
-CREATE DATABASE foo;
-USE foo;
-CREATE TABLE users (name VARCHAR(255));
-INSERT INTO users (name) VALUES ('Alice');
-INSERT INTO users (name) VALUES ('Adam');
+CHANGE MASTER TO
+  MASTER_HOST='10.0.0.11',
+  MASTER_USER='repl_ring',
+  MASTER_PASSWORD='replace-with-a-secret',
+  MASTER_PORT=3306,
+  MASTER_USE_GTID=current_pos,
+  MASTER_CONNECT_RETRY=10;
+
+START REPLICA;
 ```
+
+On Node A, connect to Node B:
+
+```sql
+CHANGE MASTER TO
+  MASTER_HOST='10.0.0.12',
+  MASTER_USER='repl_ring',
+  MASTER_PASSWORD='replace-with-a-secret',
+  MASTER_PORT=3306,
+  MASTER_USE_GTID=current_pos,
+  MASTER_CONNECT_RETRY=10;
+
+START REPLICA;
+```
+
+If the deployment requires TLS, add the appropriate `MASTER_SSL`, CA, client certificate, key, and server-certificate verification options instead of sending credentials over an unprotected path.
+
+## Verify both replication links
+
+Keep application writes stopped. Wait for any initial lag to drain, then run on both nodes:
+
+```sql
+SHOW REPLICA STATUS\G
+```
+
+Use field names rather than fixed column positions. The two sides should meet these conditions:
+
+| Check | Node A expects | Node B expects |
+| --- | --- | --- |
+| `Master_Host` | `10.0.0.12` | `10.0.0.11` |
+| `Using_Gtid` | `Current_Pos` | `Current_Pos` |
+| `Slave_IO_Running` | `Yes` | `Yes` |
+| `Slave_SQL_Running` | `Yes` | `Yes` |
+| `Last_IO_Errno` | `0` | `0` |
+| `Last_SQL_Errno` | `0` | `0` |
+| lag | drained while writes are stopped | drained while writes are stopped |
+
+`Seconds_Behind_Master` alone is not a sufficient health check. Require both threads to be running, both error numbers to be zero, and the expected opposite host to be connected.
+
+## Run a serialized two-way write test
+
+This is a controlled bootstrap test while application writes are still frozen. It is not permission for concurrent production writes to the same table.
+
+On Node A, create the verification table and wait until it appears on Node B:
+
+```sql
+CREATE DATABASE IF NOT EXISTS replication_verify;
+CREATE TABLE replication_verify.ring_probe (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  token VARCHAR(80) NOT NULL,
+  written_by ENUM('node-a', 'node-b') NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_ring_probe_token (token)
+) ENGINE=InnoDB;
+```
+
+Insert the Node A token:
+
+```sql
+INSERT INTO replication_verify.ring_probe (token, written_by)
+VALUES ('node-a-20260726', 'node-a');
+
+SELECT LAST_INSERT_ID() AS node_a_id;
+```
+
+The ID must be odd. On Node B, wait until that exact token and odd ID are visible:
+
+```sql
+SELECT id, token, written_by
+FROM replication_verify.ring_probe
+WHERE token = 'node-a-20260726';
+```
+
+Only after the Node A row is confirmed, insert on Node B:
+
+```sql
+INSERT INTO replication_verify.ring_probe (token, written_by)
+VALUES ('node-b-20260726', 'node-b');
+
+SELECT LAST_INSERT_ID() AS node_b_id;
+```
+
+The Node B ID must be even and different from the Node A ID. Finally, run this on both nodes:
+
+```sql
+SELECT id, token, written_by
+FROM replication_verify.ring_probe
+WHERE token IN ('node-a-20260726', 'node-b-20260726')
+ORDER BY id;
+```
+
+Pass only when both nodes show the same two-row set, the tokens are unique, the IDs differ, Node A's ID is odd, and Node B's ID is even. Resume application writes only after this test and another clean `SHOW REPLICA STATUS\G` check.
+
+## Stop on errors or divergence
+
+Stop new writes immediately when any of these conditions appears:
+
+- `Slave_IO_Running` or `Slave_SQL_Running` is not `Yes`;
+- `Last_IO_Errno` or `Last_SQL_Errno` is nonzero;
+- duplicate-key or row-conflict errors occur;
+- data or GTID provenance differs from the recorded snapshot;
+- an application violates row/table ownership;
+- replication lag does not drain while writes are frozen.
+
+Capture `SHOW REPLICA STATUS\G`, the relevant MariaDB error log, both GTID sets, the snapshot metadata, and the affected rows. Diagnose the initial dataset, GTID relationship, network/TLS settings, account host restrictions, and ownership rules before changing replication state. Do not skip an event merely to make the threads appear healthy; an unexplained skipped transaction can preserve divergence.
+
+## Operating limits
+
+- Ring replication is asynchronous. A disconnected node can accept local writes, which increases conflict risk when the link returns.
+- MariaDB ring replication does not resolve conflicting inserts, updates, deletes, or DDL.
+- `AUTO_INCREMENT` offsets protect generated keys only; they do not protect explicit keys or existing rows.
+- Run DDL from one coordinated node during a write freeze and wait for it to replicate before continuing.
+- Backups, restore drills, monitoring, routing, and failover policy remain separate operational responsibilities.
+- Validate this procedure on staging nodes before production use.
+
+## Official MariaDB references
+
+- [Multi-Master Ring Replication](https://mariadb.com/docs/server/ha-and-performance/standard-replication/multi-master-ring-replication)
+- [Setting Up Replication](https://mariadb.com/docs/server/ha-and-performance/standard-replication/setting-up-replication)
+- [Global Transaction ID](https://mariadb.com/docs/server/ha-and-performance/standard-replication/gtid)
+- [AUTO_INCREMENT](https://mariadb.com/docs/server/reference/data-types/auto_increment)
+- [SHOW REPLICA STATUS](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-replica-status)
+- [Files Created by mariadb-backup](https://mariadb.com/docs/server/server-usage/backup-and-restore/mariadb-backup/files-created-by-mariadb-backup)

--- a/_posts/mariadb/2024-06-14-replication-on-mariadb-en.md
+++ b/_posts/mariadb/2024-06-14-replication-on-mariadb-en.md
@@ -172,6 +172,19 @@ Apply Node B's unique option-file settings, then restart both nodes:
 sudo systemctl restart mariadb
 ```
 
+Before any write occurs on Node B, copy the GTID value from the recorded `mariadb_backup_binlog_info` into the replica position. Replace the example with the complete GTID set from the backup metadata; do not copy the binlog filename or byte position into this variable.
+
+```sql
+SET GLOBAL gtid_slave_pos='101-11-12345';
+
+SELECT
+  @@global.gtid_slave_pos,
+  @@global.gtid_current_pos,
+  @@global.gtid_binlog_pos;
+```
+
+MariaDB Backup records a primary's GTID in the backup metadata, but restoring the physical files does not automatically make that primary GTID Node B's replicated position. Setting `gtid_slave_pos` tells Node B which snapshot transactions are already present. Confirm that no replica connection or thread exists before setting it, and stop if the metadata is missing, malformed, or differs from the position recorded on Node A.
+
 Confirm the effective identities:
 
 ```sql
@@ -190,20 +203,20 @@ Node A must report server/domain `11/101` and offset `1`; Node B must report `12
 
 ### 4. Compare data and GTID provenance before connecting
 
-Compare representative row counts, checksums appropriate to the dataset, the backup metadata, and `@@global.gtid_current_pos` on both nodes.
+Compare representative row counts, checksums appropriate to the dataset, the backup metadata, `@@global.gtid_slave_pos` on Node B, and `@@global.gtid_current_pos` on both nodes.
 
-MariaDB GTIDs use `domain-server-sequence` components. Because the nodes have different `gtid_domain_id` values, do **not** require the complete GTID strings to be textually equal. Instead, verify that:
+MariaDB GTIDs use `domain-server-sequence` components. Parse and compare those components instead of trusting an unexamined string comparison. Before the initial ring connections, verify that:
 
-1. every snapshot-derived domain and sequence matches the recorded backup metadata;
-2. both nodes contain the same restored data;
-3. any additional local transaction is expected, documented with its domain/server/sequence, and explained;
-4. no unplanned write occurred after the snapshot.
+1. Node A's recorded snapshot position matches the complete GTID set in `mariadb_backup_binlog_info`;
+2. Node B's `gtid_slave_pos` contains that same snapshot-derived domain/server/sequence set;
+3. both nodes' `gtid_current_pos` contain the same snapshot position and neither node has any post-snapshot local GTID;
+4. both nodes contain the same restored data.
 
-If the data differs, snapshot-derived GTIDs are missing, or an unexplained local GTID exists, stop here. Do not run `CHANGE MASTER TO`.
+The configured `gtid_domain_id` values differ so future local transactions can use domains `101` and `102`; that setting alone does not justify an extra GTID before the ring exists. If the data differs, a snapshot GTID is missing, or either node has any post-snapshot local GTID, stop here. Do not run `CHANGE MASTER TO`, even when the extra transaction is documented. Re-freeze writes and create a fresh snapshot instead.
 
 ## Connect both replication directions
 
-`MASTER_USE_GTID=current_pos` is safe here only because writes remain frozen and the previous step proved the current positions came from the common snapshot plus documented local transactions. Local writes while replication is stopped change `gtid_current_pos`; if that happens, repeat the fail-closed comparison before connecting.
+`MASTER_USE_GTID=current_pos` is safe here only because writes remain frozen, Node B's `gtid_slave_pos` was initialized from the backup metadata, and the previous step proved that neither node has a post-snapshot local GTID. A local write while replication is stopped changes `gtid_current_pos` to a position the peer may not have; if that happens before both directions are connected, discard this bootstrap attempt and start again from a fresh snapshot.
 
 On Node B, connect to Node A:
 
@@ -342,3 +355,8 @@ Capture `SHOW REPLICA STATUS\G`, the relevant MariaDB error log, both GTID sets,
 - [AUTO_INCREMENT](https://mariadb.com/docs/server/reference/data-types/auto_increment)
 - [SHOW REPLICA STATUS](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-replica-status)
 - [Files Created by mariadb-backup](https://mariadb.com/docs/server/server-usage/backup-and-restore/mariadb-backup/files-created-by-mariadb-backup)
+- [Setting up a Replica with mariadb-backup](https://mariadb.com/docs/server/server-usage/backup-and-restore/mariadb-backup/setting-up-a-replica-with-mariadb-backup)
+
+## Related reading
+
+- [MariaDB 11 replication setup in Korean]({% link _posts/mariadb/2024-06-14-replication-on-mariadb-kr.md %})

--- a/_posts/mariadb/2024-06-14-replication-on-mariadb-en.md
+++ b/_posts/mariadb/2024-06-14-replication-on-mariadb-en.md
@@ -100,13 +100,34 @@ auto_increment_offset=2
 
 The increment of `2` gives Node A odd generated IDs and Node B even generated IDs. It reduces `AUTO_INCREMENT` collisions, but it does not resolve conflicting updates, explicit duplicate keys, or divergent DDL.
 
-Do not restart Node B with an empty or unrelated data directory yet. The safe bootstrap order below restores the shared snapshot before the final Node B start.
+Do not restart Node B with an empty or unrelated data directory yet. Keep it stopped until the shared snapshot has been restored.
+
+Stop application and maintenance writes to Node A, apply its option-file settings, and restart MariaDB on Node A before creating the replication accounts or taking the backup:
+
+```bash
+sudo systemctl restart mariadb
+```
+
+Verify the effective Node A settings:
+
+```sql
+SELECT
+  @@global.server_id,
+  @@global.gtid_domain_id,
+  @@global.log_bin,
+  @@global.log_slave_updates,
+  @@global.gtid_strict_mode,
+  @@global.auto_increment_increment,
+  @@global.auto_increment_offset;
+```
+
+Require server/domain `11/101`, binary logging and `log_slave_updates` enabled, strict GTID mode enabled, increment `2`, and offset `1`. If any value differs, stop and fix the option-file loading before creating accounts or taking a backup.
 
 ## Bootstrap both nodes from one snapshot
 
 ### 1. Freeze writes and create the replication accounts
 
-Stop application and maintenance writes on both nodes. On canonical Node A, create only the accounts that the two peer addresses need:
+Keep application and maintenance writes frozen. On canonical Node A, create only the accounts that the two peer addresses need:
 
 ```sql
 CREATE USER 'repl_ring'@'10.0.0.11' IDENTIFIED BY 'replace-with-a-secret';
@@ -166,10 +187,10 @@ sudo mariadb-backup \
 sudo chown -R mysql:mysql /var/lib/mysql
 ```
 
-Apply Node B's unique option-file settings, then restart both nodes:
+Apply Node B's unique option-file settings, then start Node B. Leave Node A running with the settings verified before the backup:
 
 ```bash
-sudo systemctl restart mariadb
+sudo systemctl start mariadb
 ```
 
 Before any write occurs on Node B, confirm that its new binary log and replica state are empty:

--- a/scripts/mcp/notion/start.sh
+++ b/scripts/mcp/notion/start.sh
@@ -2,8 +2,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ENV_FILE="${MCP_NOTION_ENV_FILE:-"$SCRIPT_DIR/.env"}"
 DEFAULT_PACKAGE_SPEC="@notionhq/notion-mcp-server@2.4.1"
+
+if [[ -n "${MCP_NOTION_ENV_FILE:-}" ]]; then
+    ENV_FILE="$MCP_NOTION_ENV_FILE"
+elif [[ -f "$SCRIPT_DIR/.env.local" ]]; then
+    ENV_FILE="$SCRIPT_DIR/.env.local"
+else
+    ENV_FILE="$SCRIPT_DIR/.env"
+fi
 
 if [[ -f "$ENV_FILE" ]]; then
     set -a

--- a/scripts/mcp/notion/start.sh
+++ b/scripts/mcp/notion/start.sh
@@ -6,10 +6,10 @@ DEFAULT_PACKAGE_SPEC="@notionhq/notion-mcp-server@2.4.1"
 
 if [[ -n "${MCP_NOTION_ENV_FILE:-}" ]]; then
     ENV_FILE="$MCP_NOTION_ENV_FILE"
-elif [[ -f "$SCRIPT_DIR/.env.local" ]]; then
-    ENV_FILE="$SCRIPT_DIR/.env.local"
-else
+elif [[ -f "$SCRIPT_DIR/.env" ]]; then
     ENV_FILE="$SCRIPT_DIR/.env"
+else
+    ENV_FILE="$SCRIPT_DIR/.env.local"
 fi
 
 if [[ -f "$ENV_FILE" ]]; then

--- a/scripts/verify-post-metadata.py
+++ b/scripts/verify-post-metadata.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Fail-closed source/front-matter to generated-HTML metadata verifier."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from datetime import datetime
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+
+
+def parse_scalar(value: str) -> Any:
+    value = value.strip()
+    if not value:
+        return ""
+    if value.startswith("[") and value.endswith("]"):
+        return [item.strip().strip("\"'") for item in value[1:-1].split(",")]
+    if value.lower() in {"true", "false"}:
+        return value.lower() == "true"
+    if value[0:1] in {"\"", "'"}:
+        return ast.literal_eval(value)
+    return value
+
+
+def parse_front_matter(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    match = re.match(r"\A---\n(.*?)\n---\n", text, re.DOTALL)
+    if not match:
+        raise ValueError(f"{path}: missing front matter")
+
+    result: dict[str, Any] = {}
+    for line in match.group(1).splitlines():
+        if not line or line.startswith((" ", "\t", "#")):
+            continue
+        key, separator, value = line.partition(":")
+        if not separator:
+            raise ValueError(f"{path}: unsupported front matter line: {line}")
+        result[key.strip()] = parse_scalar(value)
+    return result
+
+
+class MetadataParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.meta: dict[str, str] = {}
+        self.canonical = ""
+        self.title_parts: list[str] = []
+        self.h1_parts: list[str] = []
+        self.h1_values: list[str] = []
+        self.json_ld: list[dict[str, Any]] = []
+        self.has_mermaid_source = False
+        self._in_title = False
+        self._in_h1 = False
+        self._in_json_ld = False
+        self._script_parts: list[str] = []
+
+    def handle_starttag(
+        self, tag: str, attrs_list: list[tuple[str, str | None]]
+    ) -> None:
+        attrs = {key: value or "" for key, value in attrs_list}
+        if tag == "meta":
+            key = attrs.get("name") or attrs.get("property")
+            if key:
+                self.meta[key] = attrs.get("content", "")
+        elif tag == "link" and "canonical" in attrs.get("rel", "").split():
+            self.canonical = attrs.get("href", "")
+        elif tag == "title":
+            self._in_title = True
+        elif tag == "h1":
+            self._in_h1 = True
+            self.h1_parts = []
+        elif tag == "code" and "language-mermaid" in attrs.get("class", "").split():
+            self.has_mermaid_source = True
+        elif tag == "script" and attrs.get("type") == "application/ld+json":
+            self._in_json_ld = True
+            self._script_parts = []
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self.title_parts.append(data)
+        if self._in_h1:
+            self.h1_parts.append(data)
+        if self._in_json_ld:
+            self._script_parts.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self._in_title = False
+        elif tag == "h1" and self._in_h1:
+            self.h1_values.append("".join(self.h1_parts).strip())
+            self._in_h1 = False
+        elif tag == "script" and self._in_json_ld:
+            payload = "".join(self._script_parts).strip()
+            self.json_ld.append(json.loads(payload))
+            self._in_json_ld = False
+
+    @property
+    def title(self) -> str:
+        return " ".join("".join(self.title_parts).split())
+
+
+def find_json_ld(parser: MetadataParser, schema_type: str) -> dict[str, Any]:
+    for item in parser.json_ld:
+        if item.get("@type") == schema_type:
+            return item
+    raise ValueError(f"generated HTML: missing {schema_type} JSON-LD")
+
+
+def expected_modified(front_matter: dict[str, Any]) -> datetime:
+    raw = str(front_matter["last_modified_at"])
+    return datetime.strptime(raw, "%Y-%m-%d %H:%M:%S %z")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source", type=Path)
+    parser.add_argument("generated_html", type=Path)
+    parser.add_argument("--config", type=Path, default=Path("_config.yml"))
+    args = parser.parse_args()
+
+    source = parse_front_matter(args.source)
+    config: dict[str, Any] = {}
+    for line in args.config.read_text(encoding="utf-8").splitlines():
+        if line.startswith(("title:", "url:", "baseurl:")):
+            key, _, value = line.partition(":")
+            config[key] = parse_scalar(value)
+
+    required = {
+        "title",
+        "description",
+        "excerpt",
+        "tags",
+        "permalink",
+        "last_modified_at",
+        "lang",
+    }
+    missing = sorted(required - source.keys())
+    if missing:
+        raise ValueError(f"{args.source}: missing fields: {', '.join(missing)}")
+
+    generated = args.generated_html.read_text(encoding="utf-8")
+    document = MetadataParser()
+    document.feed(generated)
+    posting = find_json_ld(document, "BlogPosting")
+    find_json_ld(document, "BreadcrumbList")
+
+    tags = source["tags"]
+    if not isinstance(tags, list) or not all(tags):
+        raise ValueError(f"{args.source}: tags must be a non-empty inline list")
+    if not source["excerpt"]:
+        raise ValueError(f"{args.source}: excerpt must not be empty")
+
+    site_url = str(config.get("url", "")).rstrip("/")
+    baseurl = str(config.get("baseurl", "")).rstrip("/")
+    canonical = f"{site_url}{baseurl}{source['permalink']}"
+    tag_description = ", ".join(tags)
+    errors: list[str] = []
+
+    checks = [
+        (source["title"] in document.title, "HTML title does not contain source title"),
+        (
+            document.meta.get("description") == source["description"],
+            "meta description does not match front matter",
+        ),
+        (document.canonical == canonical, "canonical does not match permalink"),
+        (posting.get("url") == canonical, "BlogPosting URL does not match canonical"),
+        (
+            posting.get("headline") == source["title"],
+            "BlogPosting headline does not match title",
+        ),
+        (
+            posting.get("description") == source["description"],
+            "BlogPosting description does not match front matter",
+        ),
+        (
+            datetime.fromisoformat(str(posting.get("dateModified")))
+            == expected_modified(source),
+            "BlogPosting dateModified does not represent last_modified_at",
+        ),
+        (
+            posting.get("inLanguage") == source["lang"],
+            "BlogPosting language does not match front matter",
+        ),
+        (
+            all(tag in document.meta.get("keywords", "").split(", ") for tag in tags),
+            "generated keywords do not contain every front matter tag",
+        ),
+        (
+            document.meta.get("og:description") == tag_description,
+            "OG description does not match the current tag-based template contract",
+        ),
+        (
+            document.meta.get("twitter:description") == tag_description,
+            "Twitter description does not match the current tag-based template contract",
+        ),
+        (
+            document.h1_values == [source["title"]],
+            "generated HTML must contain exactly one H1 matching title",
+        ),
+        (
+            not source.get("mermaid") or document.has_mermaid_source,
+            "mermaid front matter is true but generated diagram source is missing",
+        ),
+    ]
+    for passed, message in checks:
+        if not passed:
+            errors.append(message)
+
+    if "image" not in source:
+        for field in ("og:image", "twitter:image"):
+            if field in document.meta:
+                errors.append(f"{field} must be absent when front matter has no image")
+        if "image" in posting:
+            errors.append("BlogPosting image must be absent when front matter has no image")
+
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "PASS: source, title, description, canonical, JSON-LD, tags, excerpt, "
+        "keywords, OG/Twitter, H1, image policy, and Mermaid source are consistent"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
Notion: https://app.notion.com/p/MariaDB-3a88e829740081ec9987c5ffaa0d2cc7

## Summary

- MariaDB 11.4.x 기반 2노드 비동기 GTID 링 구성 절차를 안전한 스냅샷 부트스트랩과 단일 작성자 운영 계약 중심으로 전면 개정했습니다.
- 백업 GTID를 Node B의 `gtid_slave_pos`에 명시적으로 적재하고, 최초 링 연결 전 post-snapshot 로컬 GTID를 전부 거부하도록 fail-closed 절차를 강화했습니다.
- 백업에서 제외되는 binary-log 이력을 Node B의 `gtid_binlog_state`에 복원해 역방향 연결도 같은 snapshot GTID를 인식하도록 했습니다.
- snapshot 전에 Node A 설정을 재시작·검증한 뒤 계정과 backup GTID가 새 server/domain ID로 생성되도록 순서를 고정했습니다.
- 노드별 고유 server/domain ID, AUTO_INCREMENT 홀짝 분리, 양방향 상태 점검표, 직렬화된 쓰기 검증, 중단 조건을 명시했습니다.
- 게시물 메타데이터·JSON-LD·OG/Twitter·H1·Mermaid 소스를 검증하는 표준 라이브러리 기반 검사기를 추가했습니다.

## Non-scope

- Galera 구성, 자동 장애조치, 충돌 자동 해결, 실제 운영 DB 변경은 포함하지 않습니다.

## Validation

- strict Jekyll build 통과
- metadata verifier 및 Python 구문 검사 통과
- 실제 브라우저: Mermaid 1개 → SVG 1개, Node A/B, 양방향 edge 2개, 내부 링크, 단일 H1 확인, console warning/error 없음
- `git diff --check`

Base: `develop`
Head: `fc676d745990acb2ddde79e8231e76bfa61730e5`
